### PR TITLE
Refactor README.md for better readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,156 +1,193 @@
-Document de Synthèse : Tendances et Architectures d'Interopérabilité et d'IA Agentique
+# Document de Synthèse : Tendances et Architectures d'Interopérabilité et d'IA Agentique
 
 Ce document de synthèse analyse les thèmes principaux, les idées essentielles et les faits marquants issus des sources fournies, couvrant les architectures d'intégration, les systèmes de messagerie, l'émergence des systèmes d'IA agentiques, et les défis liés à leur industrialisation, gouvernance et sécurité.
 
+## 1. Crise Actuelle de l'Intégration et Dette Technique/Cognitive
+Les sources décrivent une crise de complexité systémique dans l'intégration des applications traditionnelles, menant à une **dette technique et cognitive** croissante.
 
-1. Crise Actuelle de l'Intégration et Dette Technique/Cognitive
-Les sources décrivent une crise de complexité systémique dans l'intégration des applications traditionnelles, menant à une dette technique et cognitive croissante.
-
-1.1. L'Échec des Approches Centralisées Traditionnelles
+### 1.1. L'Échec des Approches Centralisées Traditionnelles
 Historiquement, l'intégration a été abordée par diverses méthodes, chacune présentant des limites significatives:
-Transfert de Fichiers : Simple et découplé, mais manque de rapidité et nécessite une gestion manuelle complexe des conventions, du verrouillage et de la suppression des fichiers. "Le transfert de fichiers vous permet de garder les applications très bien découplées, mais au prix de la rapidité. Les systèmes ne peuvent tout simplement pas se suivre mutuellement." (Source 1, p. 77)
-Bases de Données Partagées : Offre une réactivité, mais crée un couplage fort, des goulets d'étranglement de performance, des blocages et des difficultés d'intégration avec des packages externes ou lors de fusions d'entreprises. "Souvent, ils ne fonctionneront pas avec un schéma autre que le leur." (Source 1, p. 77)
-Appels de Procédures à Distance (RPC) : Permet le partage de fonctionnalités, mais crée un couplage étroit et des faiblesses inhérentes aux systèmes distribués (lenteur, échecs). "La téléprocédure permet aux applications de partager des fonctionnalités, mais les couple fortement dans le processus." (Source 1, p. 77)
-L'Enterprise Service Bus (ESB), bien qu'introduit pour "rembourser" la dette de l'intégration point à point, a souvent échoué en créant des "monolithes d'intégration". "trop nombreuses organisations, l'ESB n'a pas résolu la complexité ; il l'a simplement déplacée des extrémités vers le centre, créant un monolithe d'intégration." (Source 2, p. 11). Ce hub centralisé est devenu un goulot d'étranglement pour le changement et un point de défaillance unique (SPOF).
+- **Transfert de Fichiers** : Simple et découplé, mais manque de rapidité et nécessite une gestion manuelle complexe des conventions, du verrouillage et de la suppression des fichiers.
+  > "Le transfert de fichiers vous permet de garder les applications très bien découplées, mais au prix de la rapidité. Les systèmes ne peuvent tout simplement pas se suivre mutuellement." (Source 1, p. 77)
+- **Bases de Données Partagées** : Offre une réactivité, mais crée un couplage fort, des goulets d'étranglement de performance, des blocages et des difficultés d'intégration avec des packages externes ou lors de fusions d'entreprises.
+  > "Souvent, ils ne fonctionneront pas avec un schéma autre que le leur." (Source 1, p. 77)
+- **Appels de Procédures à Distance (RPC)** : Permet le partage de fonctionnalités, mais crée un couplage étroit et des faiblesses inhérentes aux systèmes distribués (lenteur, échecs).
+  > "La téléprocédure permet aux applications de partager des fonctionnalités, mais les couple fortement dans le processus." (Source 1, p. 77)
 
-1.2. La Dette Cognitive : Un Nouveau Fardeau
-Au-delà de la dette technique (coût de la maintenance du code), les sources introduisent le concept de "dette cognitive", définie comme "la charge mentale collective requise par une organisation pour comprendre, maintenir et faire évoluer son propre système d'information." (Source 2, p. 12). Cette dette se manifeste par :
-Surcharge cognitive extrinsèque : Effort mental massif pour comprendre des systèmes "spaghettis" ou la logique d'un ESB. "Cette surcharge, multipliée par des centaines d'ingénieurs et répétée quotidiennement, mène à la frustration, à la baisse de productivité, à la prise de décisions sous-optimales et, ultimement, à l'épuisement professionnel (burnout)" (Source 2, p. 12).
-Inhibiteur d'agilité : Chaque décision nécessite un effort herculéen de déchiffrage du système existant.
+L'**Enterprise Service Bus (ESB)**, bien qu'introduit pour "rembourser" la dette de l'intégration point à point, a souvent échoué en créant des "monolithes d'intégration".
+> "trop nombreuses organisations, l'ESB n'a pas résolu la complexité ; il l'a simplement déplacée des extrémités vers le centre, créant un monolithe d'intégration." (Source 2, p. 11).
+
+Ce hub centralisé est devenu un goulot d'étranglement pour le changement et un point de défaillance unique (SPOF).
+
+### 1.2. La Dette Cognitive : Un Nouveau Fardeau
+Au-delà de la dette technique (coût de la maintenance du code), les sources introduisent le concept de **"dette cognitive"**, définie comme "la charge mentale collective requise par une organisation pour comprendre, maintenir et faire évoluer son propre système d'information." (Source 2, p. 12). Cette dette se manifeste par :
+- **Surcharge cognitive extrinsèque** : Effort mental massif pour comprendre des systèmes "spaghettis" ou la logique d'un ESB.
+  > "Cette surcharge, multipliée par des centaines d'ingénieurs et répétée quotidiennement, mène à la frustration, à la baisse de productivité, à la prise de décisions sous-optimales et, ultimement, à l'épuisement professionnel (burnout)" (Source 2, p. 12).
+- **Inhibiteur d'agilité** : Chaque décision nécessite un effort herculéen de déchiffrage du système existant.
 
 
-2. Le Paradigme des Systèmes de Messagerie et des Modèles d'Intégration
-Les systèmes de messagerie sont présentés comme une solution clé pour l'intégration, offrant découplage, résilience et asynchronisme.
+## 2. Le Paradigme des Systèmes de Messagerie et des Modèles d'Intégration
+Les systèmes de messagerie sont présentés comme une solution clé pour l'intégration, offrant **découplage, résilience et asynchronisme**.
 
-2.1. Principes Fondamentaux de la Messagerie
-Système de messagerie / Middleware orienté message (MOM) : "Un système de messagerie gère la messagerie de la même manière qu'un système de base de données gère la persistance des données." (Source 1, p. 75). Son rôle principal est de déplacer les messages de manière fiable de l'expéditeur au récepteur.
-Avantages de la messagerie :
-Intégration plateforme/langage : Agit comme un "traducteur universel" entre applications utilisant différentes technologies et plateformes. "Cette connectivité universelle est le cœur du modèle Message Bus." (Source 1, p. 75).
-Opération déconnectée : Idéal pour les applications qui doivent se synchroniser lorsque le réseau est disponible (ex: appareils mobiles).
-Médiation : Le système de messagerie agit comme un médiateur, découplant les applications les unes des autres et offrant une haute disponibilité et un équilibrage de charge.
-Gestion des threads : Permet une communication asynchrone, évitant le blocage des applications.
-Découplage : Les applications sont beaucoup plus découplées qu'avec RPC ou le transfert de fichiers.
+### 2.1. Principes Fondamentaux de la Messagerie
+- **Système de messagerie / Middleware orienté message (MOM)** :
+  > "Un système de messagerie gère la messagerie de la même manière qu'un système de base de données gère la persistance des données." (Source 1, p. 75).
+  Son rôle principal est de déplacer les messages de manière fiable de l'expéditeur au récepteur.
+- **Avantages de la messagerie** :
+  - **Intégration plateforme/langage** : Agit comme un "traducteur universel" entre applications utilisant différentes technologies et plateformes.
+    > "Cette connectivité universelle est le cœur du modèle Message Bus." (Source 1, p. 75).
+  - **Opération déconnectée** : Idéal pour les applications qui doivent se synchroniser lorsque le réseau est disponible (ex: appareils mobiles).
+  - **Médiation** : Le système de messagerie agit comme un médiateur, découplant les applications les unes des autres et offrant une haute disponibilité et un équilibrage de charge.
+  - **Gestion des threads** : Permet une communication asynchrone, évitant le blocage des applications.
+  - **Découplage** : Les applications sont beaucoup plus découplées qu'avec RPC ou le transfert de fichiers.
 
-2.2. Modèles d'Intégration Basés sur la Messagerie
+### 2.2. Modèles d'Intégration Basés sur la Messagerie
 Le document "Enterprise Integration Patterns" décrit un langage de 65 modèles pour concevoir des solutions d'intégration.
-Message Channel : Le conduit de communication entre les applications. Peut être "Point-to-Point" (un seul consommateur) ou "Publish-Subscribe" (plusieurs consommateurs).
-Point-to-Point Channel : Assure qu'un message est consommé par exactement un récepteur. Ex: requêtes de transactions boursières.
-Publish-Subscribe Channel : Chaque abonné reçoit une copie du message. Ex: notifications de changement d'adresse.
-Fiabilité : Les canaux peuvent être configurés pour la persistance des messages ("Guaranteed Delivery") afin d'éviter la perte de messages en cas de panne du système de messagerie.
-Canaux spéciaux : Invalid Message Channel pour les messages non reconnus, et Dead Letter Channel pour les messages non livrables.
-Message : La charge utile de données échangées. Différents "types" de messages selon l'intention applicative :
-Command Message : Invoque une procédure dans une autre application. Ex: requête SOAP.
-Document Message : Passe un ensemble de données à une autre application. Ex: document de commande.
-Event Message : Notifie un changement. L'aspect temporel est crucial.
-Pipes and Filters : Un style architectural pour connecter des étapes de traitement logiques. Les Message Channels sont une implémentation naturelle de ces "pipes" abstraits, offrant indépendance de langage, plateforme et localisation.
-Message Router : Décide où envoyer un message basé sur des conditions. Peut être "stateless" ou "stateful" (ex: pour éliminer les doublons).
-Content-Based Router : Route le message en fonction de son contenu.
-Dynamic Router : Les destinataires annoncent dynamiquement leurs conditions de prise en charge des messages.
-Recipient List : Spécifie un ou plusieurs destinataires explicites pour un message. Peut être dynamique, permettant aux destinataires de configurer leurs préférences.
-Message Translator : Convertit le format des données entre systèmes. Essentiel pour l'intégration de systèmes hétérogènes.
-Canonical Data Model : Une approche pour réduire le nombre de traducteurs nécessaires en utilisant un format de données commun et intermédiaire. Introduit un surcoût de "double traduction" mais améliore la maintenabilité.
-Message Endpoint : Le point de connexion d'une application à un système de messagerie, gérant l'envoi et la réception de messages. Encapsule le code de messagerie et peut agir comme un Messaging Gateway. Peut être un Polling Consumer (tire les messages) ou un Event-Driven Consumer (poussé les messages via callbacks).
-Composed Message Processor : Combine Splitter, Router et Aggregator pour gérer le flux de messages pour des éléments individuels au sein d'un message plus grand.
-Splitter : Divise un message unique en plusieurs messages individuels.
-Aggregator : Recombine plusieurs messages liés en un seul, souvent utilisé après un Splitter. Gère l'ordre et la complétude des messages.
-Scatter-Gather : Envoie une requête à plusieurs destinataires et agrège les réponses.
-Process Manager : Un composant central qui gère le flux de messages à travers le système, stocke les données entre les messages et suit les progrès. Utilisé pour orchestrer des workflows complexes.
-Correlation Identifier : Permet d'associer des messages liés, comme les requêtes et les réponses dans un scénario Request-Reply.
-Return Address : Permet au répondeur de savoir où envoyer la réponse dans un scénario Request-Reply.
+- **Message Channel** : Le conduit de communication entre les applications. Peut être "Point-to-Point" (un seul consommateur) ou "Publish-Subscribe" (plusieurs consommateurs).
+  - **Point-to-Point Channel** : Assure qu'un message est consommé par exactement un récepteur. Ex: requêtes de transactions boursières.
+  - **Publish-Subscribe Channel** : Chaque abonné reçoit une copie du message. Ex: notifications de changement d'adresse.
+- **Fiabilité** : Les canaux peuvent être configurés pour la persistance des messages ("Guaranteed Delivery") afin d'éviter la perte de messages en cas de panne du système de messagerie.
+- **Canaux spéciaux** : **Invalid Message Channel** pour les messages non reconnus, et **Dead Letter Channel** pour les messages non livrables.
+- **Message** : La charge utile de données échangées. Différents "types" de messages selon l'intention applicative :
+  - **Command Message** : Invoque une procédure dans une autre application. Ex: requête SOAP.
+  - **Document Message** : Passe un ensemble de données à une autre application. Ex: document de commande.
+  - **Event Message** : Notifie un changement. L'aspect temporel est crucial.
+- **Pipes and Filters** : Un style architectural pour connecter des étapes de traitement logiques. Les **Message Channels** sont une implémentation naturelle de ces "pipes" abstraits, offrant indépendance de langage, plateforme et localisation.
+- **Message Router** : Décide où envoyer un message basé sur des conditions. Peut être "stateless" ou "stateful" (ex: pour éliminer les doublons).
+  - **Content-Based Router** : Route le message en fonction de son contenu.
+  - **Dynamic Router** : Les destinataires annoncent dynamiquement leurs conditions de prise en charge des messages.
+- **Recipient List** : Spécifie un ou plusieurs destinataires explicites pour un message. Peut être dynamique, permettant aux destinataires de configurer leurs préférences.
+- **Message Translator** : Convertit le format des données entre systèmes. Essentiel pour l'intégration de systèmes hétérogènes.
+  - **Canonical Data Model** : Une approche pour réduire le nombre de traducteurs nécessaires en utilisant un format de données commun et intermédiaire. Introduit un surcoût de "double traduction" mais améliore la maintenabilité.
+- **Message Endpoint** : Le point de connexion d'une application à un système de messagerie, gérant l'envoi et la réception de messages. Encapsule le code de messagerie et peut agir comme un **Messaging Gateway**. Peut être un **Polling Consumer** (tire les messages) ou un **Event-Driven Consumer** (poussé les messages via callbacks).
+- **Composed Message Processor** : Combine **Splitter**, **Router** et **Aggregator** pour gérer le flux de messages pour des éléments individuels au sein d'un message plus grand.
+  - **Splitter** : Divise un message unique en plusieurs messages individuels.
+  - **Aggregator** : Recombine plusieurs messages liés en un seul, souvent utilisé après un Splitter. Gère l'ordre et la complétude des messages.
+- **Scatter-Gather** : Envoie une requête à plusieurs destinataires et agrège les réponses.
+- **Process Manager** : Un composant central qui gère le flux de messages à travers le système, stocke les données entre les messages et suit les progrès. Utilisé pour orchestrer des workflows complexes.
+- **Correlation Identifier** : Permet d'associer des messages liés, comme les requêtes et les réponses dans un scénario Request-Reply.
+- **Return Address** : Permet au répondeur de savoir où envoyer la réponse dans un scénario Request-Reply.
 
-2.3. Kafka comme Pilier du "Système Nerveux Numérique"
-Apache Kafka est présenté comme une plateforme de streaming d'événements fondamentale pour construire un "Système Nerveux Numérique" (SNN).
-Kafka: Dumb Broker, Smart Consumer : Contrairement aux MOM traditionnels ("smart brokers"), Kafka est un "dumb broker" qui se contente de persister les messages, la logique de lecture étant gérée par les consommateurs ("smart consumers"). Cela contribue à sa performance et scalabilité. "Kafka inverse radicalement ce paradigme. Il est conçu autour d'un « courtier stupide » (dumb broker) et de « consommateurs intelligents » (smart consumers)." (Source 3, p. 17).
-Log Immuable : Kafka stocke les messages dans des "topics" (similaires aux tables de base de données, mais partitionnés pour la scalabilité), qui sont des journaux immuables. "Cette persistance transforme le topic Kafka en un journal d'audit immuable et réinscriptible de ce qui s'est passé." (Source 3, p. 159). Cela permet la "rejouabilité" des événements, cruciale pour reconstruire l'état d'une application en cas de panne ou pour déployer de nouveaux agents.
-Découplage temporel radical : Producteurs et consommateurs ne sont pas couplés temporellement, améliorant la résilience.
-Groupes de consommateurs : Permettent une mise à l'échelle horizontale du traitement des messages.
-Garanties de livraison : Kafka offre diverses sémantiques : At-most-once, At-least-once (par défaut, pour la fiabilité) et Exactly-Once (pour la cohérence transactionnelle).
-Kafka Connect : Un outil pour intégrer Kafka avec des systèmes externes (bases de données, APIs) via des "source connectors" (pour l'extraction) et des "sink connectors" (pour l'intégration). Le Change Data Capture (CDC) est une technique clé pour extraire les modifications des bases de données en temps réel via les logs de réplication.
-Kafka Streams : Une bibliothèque client pour construire des applications de streaming d'état, permettant des opérations stateless (transformations, filtres) et stateful (agrégations, jointures sur des fenêtres de temps).
-ksqlDB : Une interface SQL sur Kafka Streams et Kafka Connect, simplifiant le développement d'applications de streaming.
+### 2.3. Kafka comme Pilier du "Système Nerveux Numérique"
+**Apache Kafka** est présenté comme une plateforme de streaming d'événements fondamentale pour construire un **"Système Nerveux Numérique" (SNN)**.
+- **Kafka: Dumb Broker, Smart Consumer** : Contrairement aux MOM traditionnels ("smart brokers"), Kafka est un "dumb broker" qui se contente de persister les messages, la logique de lecture étant gérée par les consommateurs ("smart consumers"). Cela contribue à sa performance et scalabilité.
+  > "Kafka inverse radicalement ce paradigme. Il est conçu autour d'un « courtier stupide » (dumb broker) et de « consommateurs intelligents » (smart consumers)." (Source 3, p. 17).
+- **Log Immuable** : Kafka stocke les messages dans des "topics" (similaires aux tables de base de données, mais partitionnés pour la scalabilité), qui sont des journaux immuables.
+  > "Cette persistance transforme le topic Kafka en un journal d'audit immuable et réinscriptible de ce qui s'est passé." (Source 3, p. 159).
+  Cela permet la **"rejouabilité"** des événements, cruciale pour reconstruire l'état d'une application en cas de panne ou pour déployer de nouveaux agents.
+- **Découplage temporel radical** : Producteurs et consommateurs ne sont pas couplés temporellement, améliorant la résilience.
+- **Groupes de consommateurs** : Permettent une mise à l'échelle horizontale du traitement des messages.
+- **Garanties de livraison** : Kafka offre diverses sémantiques : **At-most-once**, **At-least-once** (par défaut, pour la fiabilité) et **Exactly-Once** (pour la cohérence transactionnelle).
+- **Kafka Connect** : Un outil pour intégrer Kafka avec des systèmes externes (bases de données, APIs) via des "source connectors" (pour l'extraction) et des "sink connectors" (pour l'intégration). Le **Change Data Capture (CDC)** est une technique clé pour extraire les modifications des bases de données en temps réel via les logs de réplication.
+- **Kafka Streams** : Une bibliothèque client pour construire des applications de streaming d'état, permettant des opérations stateless (transformations, filtres) et stateful (agrégations, jointures sur des fenêtres de temps).
+- **ksqlDB** : Une interface SQL sur Kafka Streams et Kafka Connect, simplifiant le développement d'applications de streaming.
 
 
-3. L'Entreprise Agentique : Vers l'Autonomie et l'Intelligence Collective
-Les sources décrivent une mutation profonde vers l' "Entreprise Agentique", où des agents cognitifs autonomes, propulsés par l'IA, collaborent avec les humains.
+## 3. L'Entreprise Agentique : Vers l'Autonomie et l'Intelligence Collective
+Les sources décrivent une mutation profonde vers l' **"Entreprise Agentique"**, où des **agents cognitifs autonomes**, propulsés par l'IA, collaborent avec les humains.
 
-3.1. Définition et Anatomie de l'Agent IA
-Un agent IA est défini comme un système qui, après son déploiement initial, "peut opérer avec une intervention humaine minimale ou nulle". "Sa fonction n'est pas de répondre à une question, mais d'accomplir une tâche ou d'atteindre un objectif." (Source 5, p. 6). Il est proactif et dynamique.
+### 3.1. Définition et Anatomie de l'Agent IA
+Un **agent IA** est défini comme un système qui, après son déploiement initial, "peut opérer avec une intervention humaine minimale ou nulle".
+> "Sa fonction n'est pas de répondre à une question, mais d'accomplir une tâche ou d'atteindre un objectif." (Source 5, p. 6).
+Il est proactif et dynamique.
+
 Son anatomie se compose de quatre piliers :
-Perception : Les "sens numériques" de l'agent pour observer son environnement. Principalement via la consommation d'événements (EDA) ou les appels API. "Le système de perception est le point de branchement de l'agent au "Système Nerveux Numérique" de l'entreprise." (Source 2, p. 265).
-Mémoire :
-Mémoire à court terme (contexte) : L'historique des interactions, souvent dans une base de données clé-valeur.
-Mémoire à long terme (connaissances) : Bases de connaissances externes (via Retrieval-Augmented Generation - RAG) ou bases de données relationnelles (via text-to-SQL).
-Planification/Raisonnement : Le "cerveau" de l'agent, souvent un Grand Modèle de Langage (LLM), qui décompose les objectifs en tâches, planifie leur exécution et s'adapte aux imprévus. Les architectures ReAct (Reason-Act) sont courantes.
-Action/Effecteurs : La capacité d'agir sur le monde extérieur via des "outils" (APIs, exécution de code dans un sandbox, interaction avec des bases de données). "le LLM... décide quel outil utiliser, quand l'utiliser, et avec quels arguments." (Source 2, p. 270).
+- **Perception** : Les "sens numériques" de l'agent pour observer son environnement. Principalement via la consommation d'événements (EDA) ou les appels API.
+  > "Le système de perception est le point de branchement de l'agent au "Système Nerveux Numérique" de l'entreprise." (Source 2, p. 265).
+- **Mémoire** :
+  - **Mémoire à court terme (contexte)** : L'historique des interactions, souvent dans une base de données clé-valeur.
+  - **Mémoire à long terme (connaissances)** : Bases de connaissances externes (via **Retrieval-Augmented Generation - RAG**) ou bases de données relationnelles (via **text-to-SQL**).
+- **Planification/Raisonnement** : Le "cerveau" de l'agent, souvent un **Grand Modèle de Langage (LLM)**, qui décompose les objectifs en tâches, planifie leur exécution et s'adapte aux imprévus. Les architectures **ReAct (Reason-Act)** sont courantes.
+- **Action/Effecteurs** : La capacité d'agir sur le monde extérieur via des "outils" (APIs, exécution de code dans un sandbox, interaction avec des bases de données).
+  > "le LLM... décide quel outil utiliser, quand l'utiliser, et avec quels arguments." (Source 2, p. 270).
 
-3.2. L'Interopérabilité Cognitivo-Adaptative (ICA)
-L'ICA est présentée comme la solution systémique à la crise de l'intégration, basée non plus sur une sémantique statique, mais sur l'intention et la collaboration émergente des agents.
-Définition formelle : "la faculté d'un collectif d'agents (humains et/ou artificiels) à aligner dynamiquement leurs intentions, leurs croyances, leurs capacités et leurs contextes, via des protocoles de communication explicites et interprétables, dans le but d'atteindre des objectifs communs ou de résoudre des problèmes complexes qui ne sont pas pré-programmés." (Source 2, p. 250).
-Architecture hybride : Superpose une "superstructure adaptative" (agents cognitifs) sur une "fondation déterministe" (Système Nerveux Numérique / infrastructure de communication).
+### 3.2. L'Interopérabilité Cognitivo-Adaptative (ICA)
+L'**ICA** est présentée comme la solution systémique à la crise de l'intégration, basée non plus sur une sémantique statique, mais sur l'intention et la collaboration émergente des agents.
+- **Définition formelle** :
+  > "la faculté d'un collectif d'agents (humains et/ou artificiels) à aligner dynamiquement leurs intentions, leurs croyances, leurs capacités et leurs contextes, via des protocoles de communication explicites et interprétables, dans le but d'atteindre des objectifs communs ou de résoudre des problèmes complexes qui ne sont pas pré-programmés." (Source 2, p. 250).
+- **Architecture hybride** : Superpose une "superstructure adaptative" (agents cognitifs) sur une "fondation déterministe" (Système Nerveux Numérique / infrastructure de communication).
 
-3.3. Le Maillage Agentique (Agentic Mesh)
-Le Maillage Agentique est l'architecture qui permet l'intelligence collective des agents.
-Chorégraphie événementielle : Pas d'orchestrateur central. Chaque agent réagit aux événements et publie les siens, permettant une collaboration émergente et décentralisée. "Chaque agent est un danseur autonome et intelligent qui connaît sa propre partition, mais pas la danse complète." (Source 2, p. 290).
-Résilience et scalabilité : Absence de point de défaillance unique, ajout facile de nouveaux agents.
-Journalisation immuable : Le log d'événements devient la mémoire collective du maillage pour l'audit et le débogage.
+### 3.3. Le Maillage Agentique (Agentic Mesh)
+Le **Maillage Agentique** est l'architecture qui permet l'intelligence collective des agents.
+- **Chorégraphie événementielle** : Pas d'orchestrateur central. Chaque agent réagit aux événements et publie les siens, permettant une collaboration émergente et décentralisée.
+  > "Chaque agent est un danseur autonome et intelligent qui connaît sa propre partition, mais pas la danse complète." (Source 2, p. 290).
+- **Résilience et scalabilité** : Absence de point de défaillance unique, ajout facile de nouveaux agents.
+- **Journalisation immuable** : Le log d'événements devient la mémoire collective du maillage pour l'audit et le débogage.
 
 
-4. Industrialisation et Gouvernance des Systèmes Agentiques (AgentOps)
+## 4. Industrialisation et Gouvernance des Systèmes Agentiques (AgentOps)
 L'ampleur de la transformation agentique nécessite de nouvelles disciplines et cadres opérationnels.
 
-4.1. AgentOps : Au-delà de MLOps
-AgentOps est une nouvelle discipline opérationnelle, distincte de MLOps, car elle se concentre sur la gestion du comportement des agents, pas seulement de la performance des modèles. Le défi est la "dérive comportementale", un changement dans les patrons de décision et d'action d'un agent. "La question opérationnelle fondamentale posée par l'Entreprise Agentique n'est donc plus « Le code fonctionne-t-il? » ou « Le modèle est-il performant? ». Elle devient : « L'agent se comporte-t-il de manière sûre, alignée et éthique dans un environnement dynamique? »" (Source 2, p. 367).
-Le cycle de vie AgentOps comprend :
-Conception et Charte d'Agent : Définition formelle de l'intention et des garde-fous de comportement. La "Charte d'Agent" est l'artefact de gouvernance principal.
-Développement et Tests Comportementaux : Utilisation de "golden sets" de prompts et de "LLM-as-a-judge" pour évaluer la qualité des réponses et la détection d'hallucinations.
-Déploiement progressif : Stratégies comme Blue/Green ou Canary sont essentielles pour gérer le non-déterminisme des agents.
-Observabilité comportementale : Suivi des "Indicateurs Clés d'Alignement (KAIs)" et des "Session Replays" (enregistrements des raisonnements des agents) pour auditer et comprendre le comportement.
+### 4.1. AgentOps : Au-delà de MLOps
+**AgentOps** est une nouvelle discipline opérationnelle, distincte de MLOps, car elle se concentre sur la gestion du comportement des agents, pas seulement de la performance des modèles. Le défi est la **"dérive comportementale"**, un changement dans les patrons de décision et d'action d'un agent.
+> "La question opérationnelle fondamentale posée par l'Entreprise Agentique n'est donc plus « Le code fonctionne-t-il? » ou « Le modèle est-il performant? ». Elle devient : « L'agent se comporte-t-il de manière sûre, alignée et éthique dans un environnement dynamique? »" (Source 2, p. 367).
 
-4.2. Gouvernance par la Conception (Governance-by-Design) et IA Constitutionnelle
+Le cycle de vie **AgentOps** comprend :
+- **Conception et Charte d'Agent** : Définition formelle de l'intention et des garde-fous de comportement. La **"Charte d'Agent"** est l'artefact de gouvernance principal.
+- **Développement et Tests Comportementaux** : Utilisation de "golden sets" de prompts et de **"LLM-as-a-judge"** pour évaluer la qualité des réponses et la détection d'hallucinations.
+- **Déploiement progressif** : Stratégies comme **Blue/Green** ou **Canary** sont essentielles pour gérer le non-déterminisme des agents.
+- **Observabilité comportementale** : Suivi des **"Indicateurs Clés d'Alignement (KAIs)"** et des **"Session Replays"** (enregistrements des raisonnements des agents) pour auditer et comprendre le comportement.
+
+### 4.2. Gouvernance par la Conception (Governance-by-Design) et IA Constitutionnelle
 L'alignement des agents avec les valeurs et objectifs de l'entreprise est crucial.
-Principes de gouvernance : Explicité, application automatisée, défense en profondeur, auditabilité radicale, responsabilité claire.
-IA Constitutionnelle (CAI) : Une approche d'alignement des LLM qui encode les principes de gouvernance dans une "Constitution Agentique" (ou Charte d'Agent). Ces principes sont appris par le modèle via le "Reinforcement Learning from AI Feedback (RLAIF)". "Le modèle est donc récompensé lorsqu'il génère des réponses que le PM juge conformes à la constitution." (Source 2, p. 354). Cet artefact formel est le pont entre le monde juridique et technique.
+- **Principes de gouvernance** : Explicité, application automatisée, défense en profondeur, auditabilité radicale, responsabilité claire.
+- **IA Constitutionnelle (CAI)** : Une approche d'alignement des LLM qui encode les principes de gouvernance dans une **"Constitution Agentique"** (ou Charte d'Agent). Ces principes sont appris par le modèle via le **"Reinforcement Learning from AI Feedback (RLAIF)"**.
+  > "Le modèle est donc récompensé lorsqu'il génère des réponses que le PM juge conformes à la constitution." (Source 2, p. 354).
+  Cet artefact formel est le pont entre le monde juridique et technique.
 
-4.3. Sécurité des Systèmes Agentiques
+### 4.3. Sécurité des Systèmes Agentiques
 L'introduction d'agents crée de nouveaux vecteurs d'attaque :
-OWASP Top 10 for LLM Applications : Cadre pour cartographier les risques spécifiques à l'IA générative (ex: Prompt Injection, Excessive Agency, Data Poisoning).
-Prompt Injection (injection directe et indirecte) : L'attaquant manipule le comportement de l'agent via des instructions cachées dans le prompt ou les données externes. "Un attaquant peut donc insérer des instructions dans ce qui est censé être une simple donnée, et le modèle, par sa nature même, peut interpréter cette nouvelle instruction comme prioritaire." (Source 3, p. 282).
-Excessive Agency : L'agent prend des actions autonomes dommageables en raison d'objectifs vagues ou d'outils mal configurés.
-Data Poisoning (empoisonnement des données) : Corruption de la base de connaissances (RAG) de l'agent pour manipuler durablement son comportement.
-Défenses : Moindre Privilège Agentique (RBAC/ABAC pour les outils), VPC Service Controls (pour prévenir l'exfiltration de données), Observabilité approfondie (traçage cognitif avec OpenTelemetry).
+- **OWASP Top 10 for LLM Applications** : Cadre pour cartographier les risques spécifiques à l'IA générative (ex: **Prompt Injection**, **Excessive Agency**, **Data Poisoning**).
+- **Prompt Injection (injection directe et indirecte)** : L'attaquant manipule le comportement de l'agent via des instructions cachées dans le prompt ou les données externes.
+  > "Un attaquant peut donc insérer des instructions dans ce qui est censé être une simple donnée, et le modèle, par sa nature même, peut interpréter cette nouvelle instruction comme prioritaire." (Source 3, p. 282).
+- **Excessive Agency** : L'agent prend des actions autonomes dommageables en raison d'objectifs vagues ou d'outils mal configurés.
+- **Data Poisoning (empoisonnement des données)** : Corruption de la base de connaissances (RAG) de l'agent pour manipuler durablement son comportement.
+- **Défenses** : **Moindre Privilège Agentique (RBAC/ABAC pour les outils)**, **VPC Service Controls** (pour prévenir l'exfiltration de données), **Observabilité approfondie** (traçage cognitif avec OpenTelemetry).
 
-4.4. Conformité Légale et Éthique
+### 4.4. Conformité Légale et Éthique
 Les systèmes agentiques doivent se conformer aux réglementations strictes sur la protection des données (ex: RGPD, Loi 25 au Québec).
-Droit d'accès et portabilité : Le caractère distribué des données dans une architecture agentique rend l'assemblage des informations client très complexe.
-Droit à l'effacement : Conflit avec le principe d'immuabilité des logs événementiels. La solution est le Crypto-Shredding, qui consiste à chiffrer les données personnelles et à détruire la clé d'encryptage après la période de rétention légale. "C'est l'acte de destruction de la clé qui constitue l'effacement au sens du RGPD." (Source 3, p. 340).
-Cloud DLP : Peut être utilisé pour détecter et masquer les données sensibles dans les flux d'événements.
+- **Droit d'accès et portabilité** : Le caractère distribué des données dans une architecture agentique rend l'assemblage des informations client très complexe.
+- **Droit à l'effacement** : Conflit avec le principe d'immuabilité des logs événementiels. La solution est le **Crypto-Shredding**, qui consiste à chiffrer les données personnelles et à détruire la clé d'encryptage après la période de rétention légale.
+  > "C'est l'acte de destruction de la clé qui constitue l'effacement au sens du RGPD." (Source 3, p. 340).
+- **Cloud DLP** : Peut être utilisé pour détecter et masquer les données sensibles dans les flux d'événements.
 
-4.5. L'Architecte d'Intentions
-Le rôle de l'architecte évolue d'un concepteur de systèmes techniques à un "urbaniste numérique" ou "sociologue des systèmes". "Son travail ne s'apparente plus à celui d'un ingénieur en mécanique qui conçoit et assemble des pièces, mais à celui d'un urbaniste qui crée les conditions d'émergence d'une société intelligente." (Source 2, p. 297). L' "Architecte d'Intentions" (AI) est chargé de traduire les objectifs stratégiques et éthiques de l'entreprise en "Constitutions Agentiques" vérifiables. "Il est essentiel de réitérer la finalité de cette démarche... transformer l'APM en un moteur de la transformation, un processus qui identifie activement les gisements de valeur et prescrit les stratégies pour les exploiter." (Source 2, p. 461).
+### 4.5. L'Architecte d'Intentions
+Le rôle de l'architecte évolue d'un concepteur de systèmes techniques à un "urbaniste numérique" ou "sociologue des systèmes".
+> "Son travail ne s'apparente plus à celui d'un ingénieur en mécanique qui conçoit et assemble des pièces, mais à celui d'un urbaniste qui crée les conditions d'émergence d'une société intelligente." (Source 2, p. 297).
 
-
-5. La Plateforme d'Ingénierie Interne (IDP) et les "Chemins Pavés"
-Pour industrialiser le développement et le déploiement des agents, la notion d'Ingénierie de Plateforme est cruciale.
-Platform as a Product : La plateforme de développement interne est traitée comme un produit avec un cycle de vie continu, ses développeurs étant les "clients internes".
-Internal Developer Platform (IDP) : Unifie et abstrait la complexité sous-jacente, permettant aux développeurs de se concentrer sur la logique métier.
-Chemins Pavés (Golden Paths) : Des workflows pré-configurés et automatisés qui guident les développeurs à travers les meilleures pratiques et outils, de la création de l'agent au déploiement et à l'observabilité. "Le « Chemin Pavé » est la séquence d'outils, de gabarits, de processus et de documentation que nous recommandons à nos équipes de développement pour accomplir une tâche courante de la manière la plus efficace, fiable et sécurisée." (Source 3, p. 9).
-Développement Dirigé par l'Intention : La plateforme agit comme un "compilateur d'intention", traduisant des déclarations de haut niveau (ex: YAML) en architectures et code fonctionnels, déployés et conformes. "La plateforme elle-même agit alors comme un « compilateur d’intention »." (Source 3, p. 12).
-Centre d'Habilitation (C4E) : Une équipe qui gère la plateforme, publie des actifs réutilisables et pratique la "récolte de patrons" (standardisation des solutions innovantes trouvées par les équipes).
+L' **"Architecte d'Intentions" (AI)** est chargé de traduire les objectifs stratégiques et éthiques de l'entreprise en **"Constitutions Agentiques"** vérifiables.
+> "Il est essentiel de réitérer la finalité de cette démarche... transformer l'APM en un moteur de la transformation, un processus qui identifie activement les gisements de valeur et prescrit les stratégies pour les exploiter." (Source 2, p. 461).
 
 
-6. L'Économie Cognitive et les Risques Systémiques
-Les systèmes agentiques ne se limitent pas à l'entreprise, ils façonnent une "Économie Cognitive" plus vaste.
-Constellation de Valeur Dynamique : Des alliances temporaires et auto-organisées d'agents de multiples entreprises, assemblées à la demande pour co-créer des propositions de valeur hyper-personnalisées.
-Diplomatie Algorithmique : Négociation et coordination entre agents, régies par des protocoles de confiance et des systèmes de réputation.
-Risques systémiques : L'interconnexion crée des risques de propagation à grande échelle.
-Contagion Cognitive : Propagation rapide d'informations erronées ou de modèles défectueux, provoquant des perturbations systémiques. "Cette propagation induit des actions incorrectes et corrélées de la part de millions d'agents, provoquant des perturbations systémiques." (Source 2, p. 556).
-Collusion Algorithmique : Émergence d'un comportement supra-concurrentiel entre agents sans accord explicite.
-Monoculture Cognitive : Dépendance à un nombre restreint de modèles ou d'architectures d'IA, réduisant la diversité et la résilience de l'écosystème. Comparée à la "Famine de la Pomme de Terre en Irlande". (Source 2, p. 558).
+## 5. La Plateforme d'Ingénierie Interne (IDP) et les "Chemins Pavés"
+Pour industrialiser le développement et le déploiement des agents, la notion d'**Ingénierie de Plateforme** est cruciale.
+- **Platform as a Product** : La plateforme de développement interne est traitée comme un produit avec un cycle de vie continu, ses développeurs étant les "clients internes".
+- **Internal Developer Platform (IDP)** : Unifie et abstrait la complexité sous-jacente, permettant aux développeurs de se concentrer sur la logique métier.
+- **Chemins Pavés (Golden Paths)** : Des workflows pré-configurés et automatisés qui guident les développeurs à travers les meilleures pratiques et outils, de la création de l'agent au déploiement et à l'observabilité.
+  > "Le « Chemin Pavé » est la séquence d'outils, de gabarits, de processus et de documentation que nous recommandons à nos équipes de développement pour accomplir une tâche courante de la manière la plus efficace, fiable et sécurisée." (Source 3, p. 9).
+- **Développement Dirigé par l'Intention** : La plateforme agit comme un "compilateur d'intention", traduisant des déclarations de haut niveau (ex: YAML) en architectures et code fonctionnels, déployés et conformes.
+  > "La plateforme elle-même agit alors comme un « compilateur d’intention »." (Source 3, p. 12).
+- **Centre d'Habilitation (C4E)** : Une équipe qui gère la plateforme, publie des actifs réutilisables et pratique la "récolte de patrons" (standardisation des solutions innovantes trouvées par les équipes).
 
 
-7. Le Cockpit du Berger d'Intention et l'Interface Humain-Agent
+## 6. L'Économie Cognitive et les Risques Systémiques
+Les systèmes agentiques ne se limitent pas à l'entreprise, ils façonnent une **"Économie Cognitive"** plus vaste.
+- **Constellation de Valeur Dynamique** : Des alliances temporaires et auto-organisées d'agents de multiples entreprises, assemblées à la demande pour co-créer des propositions de valeur hyper-personnalisées.
+- **Diplomatie Algorithmique** : Négociation et coordination entre agents, régies par des protocoles de confiance et des systèmes de réputation.
+- **Risques systémiques** : L'interconnexion crée des risques de propagation à grande échelle.
+  - **Contagion Cognitive** : Propagation rapide d'informations erronées ou de modèles défectueux, provoquant des perturbations systémiques.
+    > "Cette propagation induit des actions incorrectes et corrélées de la part de millions d'agents, provoquant des perturbations systémiques." (Source 2, p. 556).
+  - **Collusion Algorithmique** : Émergence d'un comportement supra-concurrentiel entre agents sans accord explicite.
+  - **Monoculture Cognitive** : Dépendance à un nombre restreint de modèles ou d'architectures d'IA, réduisant la diversité et la résilience de l'écosystème. Comparée à la "Famine de la Pomme de Terre en Irlande". (Source 2, p. 558).
+
+
+## 7. Le Cockpit du Berger d'Intention et l'Interface Humain-Agent
 La supervision des systèmes agentiques nécessite une nouvelle interface homme-machine.
-Human-on-the-Loop : L'humain ne micro-gère pas chaque décision, mais supervise, définit les intentions et intervient en cas de défaillance majeure.
-Cockpit : Une plateforme centralisée d'observabilité et de pilotage, permettant de visualiser la "santé du troupeau" (agents), de décomposer les problèmes et d'intervenir.
-Disjoncteur Éthique : Un mécanisme d'urgence pour forcer le maillage agentique dans des états dégradés mais sûrs en cas de comportement indésirable ou dangereux. "Sa finalité n'est pas de corriger un problème, mais de l'endiguer de manière radicale pour prévenir une catastrophe, donnant ainsi aux humains le temps d'analyser la situation et de décider des actions de remédiation." (Source 2, p. 425).
-En somme, l'intégration des systèmes évolue d'une connectivité technique à une interopérabilité cognitive, où les agents autonomes deviennent les acteurs clés. Cette transformation nécessite des fondations technologiques robustes (Kafka, plateformes Cloud), de nouvelles disciplines opérationnelles (AgentOps, Ingénierie de Plateforme), des cadres de gouvernance rigoureux (IA Constitutionnelle, Contrats de Données), et une réinvention du rôle humain dans la supervision de systèmes complexes et émergents.
+- **Human-on-the-Loop** : L'humain ne micro-gère pas chaque décision, mais supervise, définit les intentions et intervient en cas de défaillance majeure.
+- **Cockpit** : Une plateforme centralisée d'observabilité et de pilotage, permettant de visualiser la "santé du troupeau" (agents), de décomposer les problèmes et d'intervenir.
+- **Disjoncteur Éthique** : Un mécanisme d'urgence pour forcer le maillage agentique dans des états dégradés mais sûrs en cas de comportement indésirable ou dangereux.
+  > "Sa finalité n'est pas de corriger un problème, mais de l'endiguer de manière radicale pour prévenir une catastrophe, donnant ainsi aux humains le temps d'analyser la situation et de décider des actions de remédiation." (Source 2, p. 425).
+
+---
+
+*En somme, l'intégration des systèmes évolue d'une connectivité technique à une interopérabilité cognitive, où les agents autonomes deviennent les acteurs clés. Cette transformation nécessite des fondations technologiques robustes (Kafka, plateformes Cloud), de nouvelles disciplines opérationnelles (AgentOps, Ingénierie de Plateforme), des cadres de gouvernance rigoureux (IA Constitutionnelle, Contrats de Données), et une réinvention du rôle humain dans la supervision de systèmes complexes et émergents.*


### PR DESCRIPTION
The previous README.md was a large wall of text. This change refactors it to use proper Markdown formatting, including:

- Headings for sections and subsections
- Bold text for key terms
- Blockquotes for citations
- Bullet points for lists

This makes the document much easier to read and navigate.